### PR TITLE
updated gpg-agent-wraper to also be compatible with gpg2 versions >= 2.1

### DIFF
--- a/gpg-agent-wrapper
+++ b/gpg-agent-wrapper
@@ -1,28 +1,35 @@
-# Copyright (c) 2010 Diego E. Pettenò <flameeyes@gmail.com>
-# Available under CC-BY license (Attribution)
+#!/bin/bash
+GPGVERS=$(gpg2 --version |grep gpg|awk '{print $3}'|cut -d"." -f2 )
+if [ $GPGVERS -ge 1 ]; then
+  gpg-connect-agent /bye
+  export SSH_AUTH_SOCK=$HOME/.gnupg/S.gpg-agent.ssh
+else
+  # Copyright (c) 2010 Diego E. Pettenò <flameeyes@gmail.com>
+  # Available under CC-BY license (Attribution)
 
-if ! [ -f "${HOME}/.gpg-agent-info" ] ||
-   ! pgrep -u ${USER} gpg-agent >/dev/null; then
-	gpg-agent --daemon --enable-ssh-support --scdaemon-program /usr/libexec/scdaemon --use-standard-socket --log-file ~/.gnupg/gpg-agent.log --write-env-file
+  if ! [ -f "${HOME}/.gpg-agent-info" ] ||
+     ! pgrep -u ${USER} gpg-agent >/dev/null; then
+  	gpg-agent --daemon --enable-ssh-support --scdaemon-program /usr/libexec/scdaemon --use-standard-socket --log-file ~/.gnupg/gpg-agent.log --write-env-file
+  fi
+
+  # for ssh-agent forwarding, override gnome-keyring though!
+  if [ -n ${SSH_AUTH_SOCK} ] && \
+      [ ${SSH_AUTH_SOCK#/tmp/keyring-} = ${SSH_AUTH_SOCK} ]; then
+  
+      fwd_SSH_AUTH_SOCK=${SSH_AUTH_SOCK}
+  fi
+
+  export SSH_AUTH_SOCK
+
+  if [ "${fwd_SSH_AUTH_SOCK}" != "" ]; then
+      SSH_AUTH_SOCK=${fwd_SSH_AUTH_SOCK}
+      export SSH_AUTH_SOCK
+  fi
+
+  source ${HOME}/.gpg-agent-info
+  export GPG_AGENT_INFO
+  export SSH_AGENT_PID
+
+  GPG_TTY=$(tty)
+  export GPG_TTY
 fi
-
-# for ssh-agent forwarding, override gnome-keyring though!
-if [ -n ${SSH_AUTH_SOCK} ] && \
-    [ ${SSH_AUTH_SOCK#/tmp/keyring-} = ${SSH_AUTH_SOCK} ]; then
-
-    fwd_SSH_AUTH_SOCK=${SSH_AUTH_SOCK}
-fi
-
-export SSH_AUTH_SOCK
-
-if [ "${fwd_SSH_AUTH_SOCK}" != "" ]; then
-    SSH_AUTH_SOCK=${fwd_SSH_AUTH_SOCK}
-    export SSH_AUTH_SOCK
-fi
-
-source ${HOME}/.gpg-agent-info
-export GPG_AGENT_INFO
-export SSH_AGENT_PID
-
-GPG_TTY=$(tty)
-export GPG_TTY


### PR DESCRIPTION
Added a hack to check for gpg2 version and do the right thing if it's >= 2.1
It should work the same for gpg2 versions < 2.1, but it was only tested on a < 2.1 system with echos, as I don't currently have a smartcard enabed system running gpg2 < 2.1